### PR TITLE
fix: correct feature and limits conversion to unblock WebGPU compute path for ORT

### DIFF
--- a/crates/wasi-webgpu-wasmtime/src/to_core_conversions.rs
+++ b/crates/wasi-webgpu-wasmtime/src/to_core_conversions.rs
@@ -715,54 +715,69 @@ impl<'a> ToCore<wgpu_types::DeviceDescriptor<wgpu_core::Label<'a>>>
 
 impl ToCore<wgpu_types::Features> for Vec<webgpu::GpuFeatureName> {
     fn to_core(self, _table: &ResourceTable) -> wgpu_types::Features {
-        let features_webgpu = self
-            .into_iter()
-            .map(|feature| match feature {
-                webgpu::GpuFeatureName::DepthClipControl => {
-                    wgpu_types::FeaturesWebGPU::DEPTH_CLIP_CONTROL
+        let (features_webgpu, features_wgpu) = self.into_iter().fold(
+            (wgpu_types::FeaturesWebGPU::empty(), wgpu_types::FeaturesWGPU::empty()),
+            |(mut webgpu, mut wgpu_native), feature| {
+                match feature {
+                    webgpu::GpuFeatureName::DepthClipControl => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::DEPTH_CLIP_CONTROL;
+                    }
+                    webgpu::GpuFeatureName::Depth32floatStencil8 => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::DEPTH32FLOAT_STENCIL8;
+                    }
+                    webgpu::GpuFeatureName::TextureCompressionBc => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_BC;
+                    }
+                    webgpu::GpuFeatureName::TextureCompressionBcSliced3d => {
+                        // Not yet in FeaturesWebGPU — skip
+                    }
+                    webgpu::GpuFeatureName::TextureCompressionEtc2 => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_ETC2;
+                    }
+                    webgpu::GpuFeatureName::TextureCompressionAstc => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_ASTC;
+                    }
+                    webgpu::GpuFeatureName::TextureCompressionAstcSliced3d => {
+                        // Not yet in FeaturesWebGPU — skip
+                    }
+                    webgpu::GpuFeatureName::TimestampQuery => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::TIMESTAMP_QUERY;
+                    }
+                    webgpu::GpuFeatureName::IndirectFirstInstance => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::INDIRECT_FIRST_INSTANCE;
+                    }
+                    webgpu::GpuFeatureName::ShaderF16 => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::SHADER_F16;
+                    }
+                    webgpu::GpuFeatureName::Rg11b10ufloatRenderable => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::RG11B10UFLOAT_RENDERABLE;
+                    }
+                    webgpu::GpuFeatureName::Bgra8unormStorage => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::BGRA8UNORM_STORAGE;
+                    }
+                    webgpu::GpuFeatureName::Float32Filterable => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::FLOAT32_FILTERABLE;
+                    }
+                    webgpu::GpuFeatureName::Float32Blendable => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::FLOAT32_BLENDABLE;
+                    }
+                    webgpu::GpuFeatureName::ClipDistances => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::CLIP_DISTANCES;
+                    }
+                    webgpu::GpuFeatureName::DualSourceBlending => {
+                        webgpu |= wgpu_types::FeaturesWebGPU::DUAL_SOURCE_BLENDING;
+                    }
+                    webgpu::GpuFeatureName::Subgroups => {
+                        // Subgroups is a native wgpu feature, not a WebGPU feature
+                        wgpu_native |= wgpu_types::FeaturesWGPU::SUBGROUP;
+                    }
                 }
-                webgpu::GpuFeatureName::Depth32floatStencil8 => {
-                    wgpu_types::FeaturesWebGPU::DEPTH32FLOAT_STENCIL8
-                }
-                webgpu::GpuFeatureName::TextureCompressionBc => {
-                    wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_BC
-                }
-                webgpu::GpuFeatureName::TextureCompressionBcSliced3d => todo!(), // wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_BC_SLICED_3D,
-                webgpu::GpuFeatureName::TextureCompressionEtc2 => {
-                    wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_ETC2
-                }
-                webgpu::GpuFeatureName::TextureCompressionAstc => {
-                    wgpu_types::FeaturesWebGPU::TEXTURE_COMPRESSION_ASTC
-                }
-                webgpu::GpuFeatureName::TextureCompressionAstcSliced3d => todo!(),
-                webgpu::GpuFeatureName::TimestampQuery => {
-                    wgpu_types::FeaturesWebGPU::TIMESTAMP_QUERY
-                }
-                webgpu::GpuFeatureName::IndirectFirstInstance => {
-                    wgpu_types::FeaturesWebGPU::INDIRECT_FIRST_INSTANCE
-                }
-                webgpu::GpuFeatureName::ShaderF16 => wgpu_types::FeaturesWebGPU::SHADER_F16,
-                webgpu::GpuFeatureName::Rg11b10ufloatRenderable => {
-                    wgpu_types::FeaturesWebGPU::RG11B10UFLOAT_RENDERABLE
-                }
-                webgpu::GpuFeatureName::Bgra8unormStorage => {
-                    wgpu_types::FeaturesWebGPU::BGRA8UNORM_STORAGE
-                }
-                webgpu::GpuFeatureName::Float32Filterable => {
-                    wgpu_types::FeaturesWebGPU::FLOAT32_FILTERABLE
-                }
-                webgpu::GpuFeatureName::Float32Blendable => todo!(),
-                webgpu::GpuFeatureName::ClipDistances => todo!(), // wgpu_types::FeaturesWebGPU::CLIP_DISTANCES,
-                webgpu::GpuFeatureName::DualSourceBlending => {
-                    wgpu_types::FeaturesWebGPU::DUAL_SOURCE_BLENDING
-                }
-                webgpu::GpuFeatureName::Subgroups => todo!(),
-            })
-            .collect();
+                (webgpu, wgpu_native)
+            },
+        );
         wgpu_types::Features {
             features_webgpu,
-            // Don't enable any native features
-            features_wgpu: wgpu_types::FeaturesWGPU::default(),
+            features_wgpu,
         }
     }
 }

--- a/crates/wasi-webgpu-wasmtime/src/trait_impls.rs
+++ b/crates/wasi-webgpu-wasmtime/src/trait_impls.rs
@@ -2826,14 +2826,14 @@ impl<T: WasiWebGpuView> webgpu::HostGpuSupportedFeatures for WasiWebGpuImpl<T> {
             }
             "bgra8unorm-storage" => features.contains(wgpu_types::Features::BGRA8UNORM_STORAGE),
             "float32-filterable" => features.contains(wgpu_types::Features::FLOAT32_FILTERABLE),
-            // "float32-blendable" => {
-            //     features.contains(wgpu_types::Features::FLOAT32_BLENDABLE)
-            // }
+            "float32-blendable" => {
+                features.contains(wgpu_types::Features::FLOAT32_BLENDABLE)
+            }
             "clip-distances" => features.contains(wgpu_types::Features::CLIP_DISTANCES),
             "dual-source-blending" => features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING),
-            // "subgroups" => {
-            //     features.contains(wgpu_types::Features::SUBGROUPS)
-            // }
+            "subgroups" => {
+                features.contains(wgpu_types::Features::SUBGROUPS)
+            }
             // "texture-formats-tier1" => {
             //     features.contains(wgpu_types::Features::TEXTURE_FORMATS_TIER1)
             // }

--- a/crates/wasi-webgpu-wasmtime/src/trait_impls.rs
+++ b/crates/wasi-webgpu-wasmtime/src/trait_impls.rs
@@ -628,6 +628,9 @@ impl<T: WasiWebGpuView> webgpu::HostGpuDevice for WasiWebGpuImpl<T> {
             None,
         );
 
+        if let Some(ref e) = err {
+            eprintln!("[wasi-webgpu] create_compute_pipeline error: {e}");
+        }
         error_handler.handle_possible_error(err);
 
         Ok(self.table().push(ComputePipeline {
@@ -987,11 +990,12 @@ impl<T: WasiWebGpuView> webgpu::HostGpuAdapter for WasiWebGpuImpl<T> {
     ) -> wasmtime::Result<Result<Resource<webgpu::GpuDevice>, webgpu::RequestDeviceError>> {
         let adapter = Arc::clone(self.table().get(&adapter)?);
 
+        let device_descriptor = descriptor
+            .map(|d| d.to_core(self.table()))
+            .unwrap_or(wgpu_types::DeviceDescriptor::default());
         let device_queue_result = self.instance().adapter_request_device(
             *adapter,
-            &descriptor
-                .map(|d| d.to_core(self.table()))
-                .unwrap_or(wgpu_types::DeviceDescriptor::default()),
+            &device_descriptor,
             None,
             None,
         );
@@ -1096,9 +1100,9 @@ impl<T: WasiWebGpuView> webgpu::HostGpuQueue for WasiWebGpuImpl<T> {
             .map(|buffer| *self.table().get(&buffer).unwrap())
             .collect::<Vec<_>>();
         let queue = *(*self.table().get(&queue)?);
-        self.instance()
-            .queue_submit(queue, &command_buffers)
-            .unwrap();
+        if let Err(e) = self.instance().queue_submit(queue, &command_buffers) {
+            eprintln!("[wasi-webgpu] queue_submit error: {e:?}");
+        }
         Ok(())
     }
 
@@ -2832,7 +2836,8 @@ impl<T: WasiWebGpuView> webgpu::HostGpuSupportedFeatures for WasiWebGpuImpl<T> {
             "clip-distances" => features.contains(wgpu_types::Features::CLIP_DISTANCES),
             "dual-source-blending" => features.contains(wgpu_types::Features::DUAL_SOURCE_BLENDING),
             "subgroups" => {
-                features.contains(wgpu_types::Features::SUBGROUPS)
+                // Naga doesn't implement WGSL `enable subgroups` yet (wgpu#5555)
+                false
             }
             // "texture-formats-tier1" => {
             //     features.contains(wgpu_types::Features::TEXTURE_FORMATS_TIER1)
@@ -2900,7 +2905,8 @@ impl<T: WasiWebGpuView> webgpu::HostGpuSupportedLimits for WasiWebGpuImpl<T> {
         &mut self,
         _limits: Resource<webgpu::GpuSupportedLimits>,
     ) -> wasmtime::Result<u32> {
-        todo!()
+        // Not in wgpu Limits; return WebGPU spec default
+        Ok(24)
     }
 
     fn max_bindings_per_bind_group(
@@ -3035,7 +3041,8 @@ impl<T: WasiWebGpuView> webgpu::HostGpuSupportedLimits for WasiWebGpuImpl<T> {
         &mut self,
         _limits: Resource<webgpu::GpuSupportedLimits>,
     ) -> wasmtime::Result<u32> {
-        todo!()
+        // Not in wgpu Limits; return WebGPU spec default
+        Ok(16)
     }
 
     fn max_color_attachments(


### PR DESCRIPTION
## Summary

Fixes `todo!()` panics that prevented device creation when a guest called
`request-device` with `requiredFeatures` containing `float32-blendable`,
`clip-distances`, or `subgroups`. Also fills in two missing limit accessors
and adds error visibility improvements.

### `to_core_conversions.rs`

Rewrote `Vec<GpuFeatureName> → DeviceDescriptor` feature conversion from
`.map().collect()` into a single `FeaturesWebGPU` bitfield to a `fold` over
both `FeaturesWebGPU` and `FeaturesWGPU`. The old code had three `todo!()`
arms that would panic at runtime:

| Feature | Before | After |
|---|---|---|
| `Float32Blendable` | `todo!()` | `FeaturesWebGPU::FLOAT32_BLENDABLE` |
| `ClipDistances` | `todo!()` | `FeaturesWebGPU::CLIP_DISTANCES` |
| `Subgroups` | `todo!()` | `FeaturesWGPU::SUBGROUP` (native feature, not WebGPU) |
| `TextureCompressionBcSliced3d` | `todo!()` | skip (not yet in wgpu-types) |
| `TextureCompressionAstcSliced3d` | `todo!()` | skip (not yet in wgpu-types) |

`Subgroups` is notable: it maps to `FeaturesWGPU::SUBGROUP`, not
`FeaturesWebGPU`, so the fold must accumulate both bitfield types separately.

### `trait_impls.rs`

- **`HostGpuSupportedFeatures::has()`**: uncomment `float32-blendable` and
`subgroups` arms. `subgroups` returns `false` unconditionally — Naga does
not yet implement `enable subgroups;` (https://github.com/gfx-rs/wgpu/issues/5555); returning `true` causes
ORT to emit subgroup WGSL that Naga rejects at pipeline compilation.
- **`max_bind_groups_plus_vertex_buffers`**: `todo!()` → `24` (WebGPU spec
default; not present in wgpu `Limits`).
- **`max_inter_stage_shader_variables`**: `todo!()` → `16` (WebGPU spec
default; not present in wgpu `Limits`).
- **`create_compute_pipeline`**: log error before `handle_possible_error` so
shader compilation failures surface in host output.
- **`queue_submit`**: replace `.unwrap()` with graceful `eprintln!` — a
submit failure should not panic the host.

### Context

These changes were found while running ONNXRuntime's WebGPU execution provider
through the wasi:webgpu stack. ORT's `requestDevice` call lists
`float32-blendable` (and others) in `requiredFeatures`; the `todo!()` panics
killed device creation before any GPU work could run. With these fixes, ORT
runs end-to-end WebGPU compute inference correctly.

This is required for https://github.com/wasi-gfx/wasi-webgpu-headers/pull/29
